### PR TITLE
build: print code version to SmartDashboard

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2,29 +2,46 @@
 
 <project name="FRC Deployment" default="deploy">
 
-  <!--
-  The following properties can be defined to override system level
-  settings. These should not be touched unless you know what you're
-  doing. The primary use is to override the wpilib version when
-  working with older robots that can't compile with the latest
-  libraries.
-  -->
+	<!-- inspired by http://llbit.se/?p=1876 -->
+	<!-- get a new version string using git describe if possible -->
+	<echo message="Updating version string..." />
+	<exec executable="git" outputproperty="code-version" errorproperty="code-version" failifexecutionfails="false">
+		<arg line="describe --tags" />
+	</exec>
+	<echo message="Version string found: ${code-version}" />
 
-  <!-- By default the system version of WPI is used -->
-  <!-- <property name="version" value=""/> -->
+	<property file="${user.home}/wpilib/wpilib.properties" />
+	<property file="build.properties" />
+	<property file="${user.home}/wpilib/java/${version}/ant/build.properties" />
 
-  <!-- By default the system team number is used -->
-  <!-- <property name="team-number" value=""/> -->
+	<property name="docs.dir" value="${build.dir}/docs" />
 
-  <!-- By default the target is set to 10.TE.AM.2 -->
-  <!-- <property name="target" value=""/> -->
+	<!-- system environment variables like user.name -->
+	<property environment="env" />
 
-  <!-- Any other property in build.properties can also be overridden. -->
-  
-  <property file="${user.home}/wpilib/wpilib.properties"/>
-  <property file="build.properties"/>
-  <property file="${user.home}/wpilib/java/${version}/ant/build.properties"/>
-  
-  <import file="${wpilib.ant.dir}/build.xml"/>
+	<tstamp>
+		<!-- current time in this format: Jul 08, 04:34 PM -->
+		<format property="build-date" pattern="MMM dd, hh:mm a" />
+	</tstamp>
 
-</project> 
+	<target name="javadoc">
+		<macro-javadocs />
+	</target>
+
+	<target name="javadocs">
+		<macro-javadocs />
+	</target>
+	<macrodef name="macro-javadocs">
+		<sequential>
+			<mkdir dir="${docs.dir}" />
+
+			<javadoc sourcepath="src" destdir="${docs.dir}" use="true" linksource="true" />
+		</sequential>
+	</macrodef>
+
+	<!-- <import file="${wpilib.ant.dir}/build.xml"/> -->
+	<!-- We need to use a custom script for versions. -->
+
+	<import file="custom_wpi_build.xml" />
+
+</project>

--- a/custom_wpi_build.xml
+++ b/custom_wpi_build.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project name="athena-project-build" default="deploy">
+
+  <!-- Load Tasks -->
+  <taskdef resource="net/sf/antcontrib/antlib.xml">
+    <classpath>
+      <pathelement location="${wpilib.ant.dir}/ant-contrib.jar"/>
+    </classpath>
+  </taskdef>
+  <taskdef resource="net/jtools/classloadertask/antlib.xml" classpath="${classloadertask.jar}"/>
+  <classloader loader="system" classpath="${jsch.jar}"/>
+
+  <target name="clean" description="Clean up all build and distribution artifacts.">
+    <delete dir="${build.dir}"/>
+    <delete dir="${dist.dir}"/>
+  </target>
+
+  <!-- Targets -->
+
+  <target name="get-target-ip">
+    <property name="ant.enable.asserts" value="true"/>
+	<assert name="team-number" exists="true" message="Team number not set. Go to Window->Preferences->WPILib Preferences to set it."/>
+    <property name="target" value="roboRIO-${team-number}-FRC.local" />
+	<echo>Trying Target: ${target}</echo>
+	 <if>
+		<isreachable host="${target}" timeout="5"/>
+	  <then>
+		<echo>roboRIO found via mDNS</echo>
+	  </then>
+	  <else>
+		<var name="target" unset="true"/>
+		<echo> roboRIO not found via mDNS, falling back to static USB</echo>
+		<property name="target" value="172.22.11.2"/>
+		<if>
+			<isreachable host="${target}" timeout="5"/>
+		  <then>
+			<echo>roboRIO found via static USB</echo>
+		  </then>
+		  <else>
+			<var name="target" unset="true"/>
+			<math result="ip.upper" operand1="${team-number}" operation="/" operand2="100" datatype="int"/>
+			<math result="ip.lower" operand1="${team-number}" operation="%" operand2="100" datatype="int"/>
+			<property name="target" value="10.${ip.upper}.${ip.lower}.2"/>
+			<echo>roboRIO not found via USB, falling back to static address of ${target}</echo>
+			<assert name="roboRIOFound" message="roboRIO not found, please check that the roboRIO is connected, imaged and that the team number is set properly in Eclipse">
+				<bool>
+					<isreachable host="${target}" timeout="5"/>
+				</bool>
+			</assert>
+			<echo>roboRIO found via Ethernet static</echo>
+		  </else>
+		</if>
+	  </else>
+	 </if>
+  </target>
+
+  <target name="compile" description="Compile the source code.">
+    <mkdir dir="${build.dir}"/>
+	<property name="userLibs" value=""/>
+    <echo>[athena-compile] Compiling ${src.dir} with classpath=${classpath}:${userLibs} to ${build.dir}</echo>
+
+    <javac srcdir="${src.dir}"
+     destdir="${build.dir}"
+     includeAntRuntime="no"
+     includeJavaRuntime="no"
+     classpath="${classpath}:${userLibs}"
+     target="${ant.java.version}"
+     source="${ant.java.version}"
+     compiler="javac${ant.java.version}"
+     debug="true">
+    </javac>
+  </target>
+
+  <target name="jar" depends="compile">
+    <echo>[athena-jar] Making jar ${dist.jar}.</echo>
+    <mkdir dir="${dist.dir}" />
+    <mkdir dir="${build.jars}" />
+
+  <echo>[athena-jar] Copying jars from ${classpath}:${userLibs} to ${build.jars}.</echo>
+  <copy todir="${build.jars}" flatten="true">
+    <path>
+    <pathelement path="${classpath}:${userLibs}"/>
+    </path>
+  </copy>
+
+    <jar destfile="${dist.jar}" update="false">
+      <manifest>
+    	<attribute name="Main-Class" value="edu.wpi.first.wpilibj.RobotBase"/>
+    	<attribute name="Robot-Class" value="${robot.class}"/>
+    	<attribute name="Class-Path" value="."/>
+    	<attribute name="Code-Version" value="${code-version}"/>
+    	<attribute name="Built-At" value="${build-date}"/>
+    	<attribute name="Built-By" value="${user.name}"/>
+      </manifest>
+
+      <fileset dir="${build.dir}" includes="**/*.class"/>
+
+    <zipgroupfileset dir="${build.jars}">
+      <include name="**/*.jar" />
+    </zipgroupfileset>
+    </jar>
+  </target>
+
+    <!-- We're running a clean here to get around a known ant issue where it does not detected changed constant variables.
+     To get around this, we're recompiling the entire project, which is not an issue for most teams. If this is an issue
+     for you, you can remove the clean here, just be sure to do a full rebuild after you've changed any constants.
+     Reference: http://stackoverflow.com/questions/6430001/ant-doesnt-recompile-constants -->
+  <target name="deploy" depends="clean,jar,get-target-ip,dependencies" description="Deploy the jar and start the program running.">
+    <echo>[athena-deploy] Copying code over.</echo>
+    <scp file="${dist.jar}" todir="${username}@${target}:${deploy.dir}" password="${password}" trust="true"/>
+
+     <!-- Suppress the exit status so that if no netconsole was running then
+          it doesn't show up red on the output. -->
+      <sshexec host="${target}"
+               username="admin"
+               password="${password}"
+               trust="true"
+               failonerror="false"
+               command="killall -q netconsole-host || :"/>
+
+      <scp file="${wpilib.ant.dir}/robotCommand" todir="${username}@${target}:${command.dir}" password="${password}" trust="true"/>
+
+    <echo>[athena-deploy] Starting program.</echo>
+    <sshexec host="${target}"
+       username="${username}"
+       password="${password}"
+       trust="true"
+	   failonerror="false"
+       command="${deploy.kill.command};"/>
+
+    <sshexec host="${target}"
+         username="${username}"
+         password="${password}"
+         trust="true"
+         command="sync" />
+
+  </target>
+
+  <target name="debug-deploy" depends="jar,get-target-ip,dependencies" description="Deploy the jar and start the program running.">
+    <echo>[athena-deploy] Copying code over.</echo>
+    <scp file="${dist.jar}" todir="${username}@${target}:${deploy.dir}" password="${password}" trust="true"/>
+  	<!-- The remoteDebugCommand file is used by /usr/local/frc/bin/frcRunRobot.sh on the roboRIO  -->
+    <scp file="${wpilib.ant.dir}/robotDebugCommand" todir="${username}@${target}:${command.dir}" password="${password}" trust="true"/>
+  	<!-- The frcdebug file is used as a flag for /usr/local/frc/bin/frcRunRobot.sh to run the robot program in debug mode -->
+  	<scp file="${wpilib.ant.dir}/frcdebug" todir="${username}@${target}:${debug.flag.dir}" password="${password}" trust="true"/>
+	<sshexec host="${target}"
+        username="${username}"
+        password="${password}"
+        trust="true"
+        command="${debug.flag.command}"/>
+
+    <echo>[athena-deploy] Starting Debug program.</echo>
+    <sshexec host="${target}"
+        username="${username}"
+        password="${password}"
+        trust="true"
+		failonerror="false"
+        command="${deploy.kill.command}"/>
+
+  </target>
+
+  <!-- Simulate -->
+  <target name="jar-for-simulation" depends="compile">
+	<echo>[jar-for-simulation] Building jar.</echo>
+
+	<jar destfile="${simulation.dist.jar}">
+	  <manifest>
+		<attribute name="Built-By" value="${user.name}"/>
+		<attribute name="Robot-Class" value="${robot.class}"/>
+		<attribute name="Main-Class" value="edu.wpi.first.wpilibj.RobotBase"/>
+	  </manifest>
+	  <fileset dir="${build.dir}" />
+	  <zipgroupfileset dir="${wpilib.sim.lib}">
+	  	<include name="**/*.jar" />
+	  </zipgroupfileset>
+	</jar>
+  </target>
+
+  <target name="simulate" depends="jar-for-simulation">
+    <sequential>
+      <echo>[simulate] You may now run Gazebo and your DriverStation</echo>
+	    <echo>[simulate] Running Code.</echo>
+	    <java jar="${simulation.dist.jar}" fork="true">
+          <jvmarg value="-Djava.library.path=${wpilib.sim.lib}" />
+      </java>
+    </sequential>
+  </target>
+
+  <target name="debug-simulate" depends="jar-for-simulation">
+    <sequential>
+      <echo>[simulate] You may now run Gazebo and your DriverStation</echo>
+	    <echo>[simulate] Running Code In Debug Mode.</echo>
+	    <java jar="${simulation.dist.jar}" fork="true">
+          <jvmarg value="-Xdebug" />
+          <jvmarg value="-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8348" />
+          <jvmarg value="-Djava.library.path=${wpilib.sim.lib}" />
+        </java>
+    </sequential>
+  </target>
+
+  <target name="dependencies" depends="get-target-ip">
+    <property name="ant.enable.asserts" value="true"/>
+	<post to="http://${target}/nisysapi/server" logfile="sysProps.xml" verbose="false" encoding="UTF-16LE" append="false">
+		<prop name="Function" value="GetPropertiesOfItem"/>
+		<prop name="Plugins" value="nisyscfg"/>
+		<prop name="Items" value="system"/>
+	</post>
+	<loadfile srcFile="sysProps.xml" encoding="UTF-16LE" property="roboRIOSysValues"/>
+	<propertyregex property="roboRIOImage" input="${roboRIOSysValues}" regexp="FRC_roboRIO_2016_v([0-9]+)" select="\1" defaultValue="ImageRegExFail"/>
+	<assert message="roboRIO Image does not match plugin, allowed image version: ${roboRIOAllowedImages}">
+		<bool>
+			<contains string="${roboRIOAllowedImages}" substring="${roboRIOImage}"/>
+		</bool>
+	</assert>
+	<echo>roboRIO image version validated</echo>
+	<echo>Checking for JRE. If this fails install the JRE using these instructions: https://wpilib.screenstepslive.com/s/4485/m/13503/l/288822-installing-java-8-on-the-roborio-using-the-frc-roborio-java-installer-java-only</echo>
+	<sshexec host="${target}"
+        username="${username}"
+        password="${password}"
+        trust="true"
+		failonerror="true"
+        command="test -d ${roboRIOJRE.dir}"/>
+  </target>
+</project>

--- a/src/org/usfirst/frc/team4915/stronghold/OI.java
+++ b/src/org/usfirst/frc/team4915/stronghold/OI.java
@@ -5,35 +5,18 @@ import edu.wpi.first.wpilibj.buttons.JoystickButton;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import org.usfirst.frc.team4915.stronghold.commands.IntakeLauncher.IntakeBallCommandGroup;
 import org.usfirst.frc.team4915.stronghold.commands.IntakeLauncher.LaunchBallCommandGroup;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 /**
- * This class is the glue that binds the controls on the physical operator
- * interface to the commands and command groups that allow control of the robot.
+ * This class handles the "operator interface", or the interactions between the
+ * driver station and the robot code.
  */
 public class OI {
-    //// CREATING BUTTONS
-    // One type of button is a joystick button which is any button on a
-    // joystick.
-    // You create one by telling it which joystick it's on and which button
-    // number it is.
-    // Joystick stick = new Joystick(port);
-    // Button button = new JoystickButton(stick, buttonNumber);
-
-    // There are a few additional built in buttons you can use. Additionally,
-    // by subclassing Button you can create custom triggers and bind those to
-    // commands the same as any other Button.
-
-    //// TRIGGERING COMMANDS WITH BUTTONS
-    // Once you have a button, it's trivial to bind it to a button in one of
-    // three ways:
-
-    // Start the command when the button is pressed and let it run the command
-    // until it is finished as determined by it's isFinished method.
-    // button.whenPressed(new ExampleCommand());
-
-    // Run the command while the button is being held down and interrupt it once
-    // the button is released.
-    // button.whileHeld(new ExampleCommand());
 
     // Start the command when the button is released and let it run the command
     // until it is finished as determined by it's isFinished method.
@@ -67,6 +50,23 @@ public class OI {
         // binds commands to buttons
         this.grabBallButton.whenPressed(new IntakeBallCommandGroup());
         this.launchBallButton.whenPressed(new LaunchBallCommandGroup());
+
+        try (InputStream manifest = getClass().getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF")) {
+            Attributes attributes = new Manifest(manifest).getMainAttributes();
+
+            /* Print the attributes into form fields on the dashboard */
+            SmartDashboard.putString("Code Version", attributes.getValue("Code-Version"));
+            SmartDashboard.putString("Built At", attributes.getValue("Built-At"));
+            SmartDashboard.putString("Built By", attributes.getValue("Built-By"));
+
+            /* And print the attributes into the log. */
+            System.out.println("Code Version: " + attributes.getValue("Code-Version"));
+            System.out.println("Built At: " + attributes.getValue("Built-At"));
+            System.out.println("Built By: " + attributes.getValue("Built-By"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
     }
 
     public Joystick getJoystickDrive() {


### PR DESCRIPTION
- build.xml
  
  This file is what's first looked at by the build system. Before
  continuing, it executes `git describe --tags`. This command fetches
  the current commit number.
  
  It also makes a note of the current time, then proceeds to running the
  code in "custom_wpi_build.xml".
- custom_wpi_build.xml
  
  This is a complete copy of the default build.xml file that ships with
  the WPILib plugin. It's normally located in the "wpilib" folder in
  your home folder.
  
  It has been modified slightly to add several attributes to the
  manifest file of the deployed code. Basically, it saves the
  (previously obtained) commit number, your username, and the current
  time to a special file inside the code deployment. These values can be
  retreived later, when the code is running. The values are listed here:
  
  | Value | Meaning | Example |
  | --- | --- | --- |
  | Code-Version | The current git commit plus version number | 0.0.0-5-gab9ed68 |
  | Built-At | Time and date when the code was deployed | Jan 18, 03:08 PM |
  | Built-By | Username of who deployed the code | jack |
- `OI`
  
  Inside the constructor of the `OI` class, several lines have been added
  to fetch the aforementioned values from the manifest. The manifest is
  first loaded from the class loader, which knows where to find
  "resource" files inside the code deployment. The manifest is always
  named "MANIFEST.MF" inside the "META-INF" folder. Manifest objects
  have Attributes, which is a list of properties you can get by name.
  
  The operations are wrapped inside a `try/catch` block, because an error
  will pop up if you try to fetch a resource file that doesn't exist,
  even if it, well, always will exist. That's why there is very little
  error handling inside the `catch` block -- it'll probably never get
  called.
