### PR TITLE
Scale the tower!

### DIFF
--- a/src/org/usfirst/frc/team4915/stronghold/ModuleManager.java
+++ b/src/org/usfirst/frc/team4915/stronghold/ModuleManager.java
@@ -9,4 +9,5 @@ public final class ModuleManager {
     public static final boolean INTAKELAUNCHER_MODULE_ON = false;  
     public static final boolean VISION_MODULE_ON = true;
     public static final boolean IMU_MODULE_ON = false;
+    public static final boolean SCALING_MODULE_ON = false;
 }

--- a/src/org/usfirst/frc/team4915/stronghold/OI.java
+++ b/src/org/usfirst/frc/team4915/stronghold/OI.java
@@ -8,12 +8,15 @@ import org.usfirst.frc.team4915.stronghold.commands.GearShiftCommand;
 import org.usfirst.frc.team4915.stronghold.commands.IntakeLauncher.IncrementLauncherHeightCommand;
 import org.usfirst.frc.team4915.stronghold.commands.IntakeLauncher.IntakeBallCommandGroup;
 import org.usfirst.frc.team4915.stronghold.commands.IntakeLauncher.LaunchBallCommandGroup;
+import org.usfirst.frc.team4915.stronghold.commands.ScalerCommand;
+import org.usfirst.frc.team4915.stronghold.subsystems.Scaler.State;
 import org.usfirst.frc.team4915.stronghold.vision.robot.AutoAimControlCommand;
 import org.usfirst.frc.team4915.stronghold.vision.robot.VisionState;
 
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.buttons.JoystickButton;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
 /**
  * This class handles the "operator interface", or the interactions between the
  * driver station and the robot code.
@@ -40,6 +43,10 @@ public class OI {
     public static final int LAUNCHER_UP_BUTTON_NUMBER = 7;
     public static final int LAUNCHER_DOWN_BUTTON_NUMBER = 6;
 
+    // FIXME: Scaling button values
+    public static final int SCALER_EXTEND_BUTTON_NUMBER = 9;
+    public static final int SCALER_RETRACT_BUTTON_NUMBER = 10;
+
     public static final int UP_DIRECTION = 1;
     public static final int DOWN_DIRECTION = UP_DIRECTION * -1;
 
@@ -55,6 +62,8 @@ public class OI {
     public JoystickButton autoAimButton;
     public JoystickButton launcherUpButton;
     public JoystickButton launcherDownButton;
+    public JoystickButton scalerExtendButton;
+    public JoystickButton scalerRetractButton;
 
     public OI() {
         this.driveStick = new Joystick(DRIVE_STICK_PORT);
@@ -101,6 +110,17 @@ public class OI {
             this.autoAimButton = new JoystickButton(this.aimStick, AUTO_AIM_BUTTON_NUMBER);
             this.autoAimButton.whenPressed(new AutoAimControlCommand());
             System.out.println("ModuleManager OI: Initialize Vision!");
+        }
+
+        if (ModuleManager.SCALING_MODULE_ON) {
+            SmartDashboard.putData("Scaler Top Switch", RobotMap.SCALING_TOP_SWITCH);
+            SmartDashboard.putData("Scaler Bottom Switch", RobotMap.SCALING_BOTTOM_SWITCH);
+            SmartDashboard.putData("Scaler Winch", RobotMap.SCALING_WINCH);
+            SmartDashboard.putData("Scaler Tape Measure Motor", RobotMap.SCALING_MOTOR);
+            this.scalerExtendButton = new JoystickButton(this.aimStick, SCALER_EXTEND_BUTTON_NUMBER);
+            this.scalerRetractButton = new JoystickButton(this.aimStick, SCALER_RETRACT_BUTTON_NUMBER);
+            this.scalerExtendButton.whenPressed(new ScalerCommand(State.EXTENDED));
+            this.scalerRetractButton.whenPressed(new ScalerCommand(State.RETRACTED));
         }
 
         /*

--- a/src/org/usfirst/frc/team4915/stronghold/RobotMap.java
+++ b/src/org/usfirst/frc/team4915/stronghold/RobotMap.java
@@ -6,6 +6,7 @@ import edu.wpi.first.wpilibj.CANTalon.FeedbackDevice;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 import edu.wpi.first.wpilibj.Servo;
+import edu.wpi.first.wpilibj.TalonSRX;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
 
 public class RobotMap {
@@ -51,6 +52,9 @@ public class RobotMap {
     private static final int LAUNCHER_TOP_SWITCH_PORT = 2;
 
     private static final int LAUNCHER_SERVO_PORT = 17;
+
+    private static final int SCALING_BOTTOM_SWITCH_PORT = 18; // TODO
+    private static final int SCALING_TOP_SWITCH_PORT = 19; // TODO
     // not actual port values
 
     private static final double AIM_MOTOR_FORWARD_SOFT_LIMIT = 234234234;
@@ -59,6 +63,12 @@ public class RobotMap {
     private static final double AIM_MOTOR_I = 0; // TODO
     private static final double AIM_MOTOR_D = 0; // TODO
 
+    public static TalonSRX SCALING_MOTOR;
+    public static TalonSRX SCALING_WINCH;
+    public static DigitalInput SCALING_BOTTOM_SWITCH;
+    public static DigitalInput SCALING_TOP_SWITCH;
+
+    /* FIXME: to delete as the switches connect directly to Talon */
     public static DigitalInput boulderSwitch;
     public static DigitalInput launcherTopSwitch;
     public static DigitalInput launcherBottomSwitch;
@@ -118,6 +128,12 @@ public class RobotMap {
             System.out.println("ModuleManager RobotMap initalize TODO: TODO Initialize Gyro!"); // gyro
                                                                                                 // instantiation
             gyro = new AnalogGyro(GYRO_PORT);
+        }
+
+        if (ModuleManager.SCALING_MODULE_ON) {
+            System.out.println("ModuleManager RobotMap Initialize: Scaling");
+            SCALING_BOTTOM_SWITCH = new DigitalInput(SCALING_BOTTOM_SWITCH_PORT);
+            SCALING_TOP_SWITCH = new DigitalInput(SCALING_TOP_SWITCH_PORT);
         }
     }
     }

--- a/src/org/usfirst/frc/team4915/stronghold/commands/ScalerCommand.java
+++ b/src/org/usfirst/frc/team4915/stronghold/commands/ScalerCommand.java
@@ -1,0 +1,49 @@
+package org.usfirst.frc.team4915.stronghold.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import org.usfirst.frc.team4915.stronghold.RobotMap;
+import org.usfirst.frc.team4915.stronghold.subsystems.Scaler;
+import org.usfirst.frc.team4915.stronghold.subsystems.Scaler.State;
+
+public class ScalerCommand extends Command {
+
+    public static final double MOTOR_SPEED = 0.7;
+    public static final double WINCH_SPEED = -0.7;
+    private final Scaler.State target;
+
+    public ScalerCommand(State target) {
+        this.target = target;
+    }
+
+    @Override
+    protected void initialize() {
+    }
+
+    @Override
+    protected void execute() {
+        switch (target) {
+            case RETRACTED:
+                RobotMap.SCALING_WINCH.set(WINCH_SPEED);
+                break;
+            case EXTENDED:
+                RobotMap.SCALING_MOTOR.set(MOTOR_SPEED);
+                break;
+            default:
+                System.out.println("Invalid scaler state " + target);
+        }
+    }
+
+    @Override
+    protected boolean isFinished() {
+        return RobotMap.SCALING_BOTTOM_SWITCH.get() || RobotMap.SCALING_TOP_SWITCH.get();
+    }
+
+    @Override
+    protected void end() {
+    }
+
+    @Override
+    protected void interrupted() {
+    }
+
+}

--- a/src/org/usfirst/frc/team4915/stronghold/subsystems/Scaler.java
+++ b/src/org/usfirst/frc/team4915/stronghold/subsystems/Scaler.java
@@ -1,0 +1,20 @@
+package org.usfirst.frc.team4915.stronghold.subsystems;
+
+import edu.wpi.first.wpilibj.command.Subsystem;
+import org.usfirst.frc.team4915.stronghold.commands.ScalerCommand;
+
+public class Scaler extends Subsystem {
+
+    @Override
+    protected void initDefaultCommand() {
+        setDefaultCommand(new ScalerCommand(State.RETRACTED));
+    }
+
+    public static enum State {
+
+        RETRACTED,
+        EXTENDED
+
+    }
+
+}


### PR DESCRIPTION
- New module added, SCALING_MODULE_ON. Disabled by default.
- A new subsystem, Scaler, was added. It has a nested State enum to
  represent the scaler being extended or retracted.
- One command, ScalerCommand, handles retraction and extension through a
  constructor parameter that is switched on when executed. This command
  has some internal values for the motor speed of the winch and the
  small motor driving the tape measure. These should probably be adjusted.
- Buttons 9 and 10 on the aiming stick have been allocated to extend and
  retract, respectively.
