### PR TITLE
Added support for absolute vs relative vision targeting.

### DIFF
--- a/src/org/usfirst/frc/team4915/stronghold/commands/DriveTrain/ArcadeDrive.java
+++ b/src/org/usfirst/frc/team4915/stronghold/commands/DriveTrain/ArcadeDrive.java
@@ -47,17 +47,32 @@ public class ArcadeDrive extends Command {
             Robot.driveTrain.trackGyro();
         }
 
+        VisionState vs = VisionState.getInstance();
+        double heading;
+        if (ModuleManager.IMU_MODULE_ON) {
+            heading = RobotMap.imu.getHeading();
+            SmartDashboard.putNumber("IMU heading", (int)(heading+.5));
+            vs.updateIMUHeading(heading);
+        } else {
+            heading = 0.0;
+        }
+
         Robot.driveTrain.joystickThrottle = Robot.driveTrain.modifyThrottle();
 
-        if (VisionState.getInstance().wantsControl()) {
-            System.out.println("Arcade Drive: driving with vision \n");
-            if (VisionState.getInstance().TargetX <= -1) {
-                Robot.driveTrain.turn(false);
+        if (vs.wantsControl()) {
+            if (vs.RelativeTargetingMode) {
+                if (Math.abs(vs.TargetX) < 3) {
+                    Robot.driveTrain.stop(); // close enough
+                } else {
+                    Robot.driveTrain.autoturn(vs.TargetX < 0);
+                }
             } else {
-                Robot.driveTrain.turn(true);
+                /* absolute autotargeting */
+                Robot.driveTrain.turnToward(vs.TargetX);
             }
         } else {
-            if ((Math.abs(this.joystickX) < Math.abs(0.075)) && (Math.abs(this.joystickY) < Math.abs(0.075))) {
+            if ((Math.abs(this.joystickX) < 0.075) && 
+                (Math.abs(this.joystickY) < 0.075)) {
                 Robot.driveTrain.stop();
             } else {
                 Robot.driveTrain.arcadeDrive(this.joystickDrive);
@@ -67,25 +82,16 @@ public class ArcadeDrive extends Command {
 
             if (ModuleManager.IMU_MODULE_ON) {
                 BNO055.CalData calData = RobotMap.imu.getCalibration();
-                int num = (int) (.5 + RobotMap.imu.getHeading());
                 distFromOrigin = BNO055.getInstance().getDistFromOrigin();
-
                 SmartDashboard.putNumber("DistFromOrigin", distFromOrigin);
                 SmartDashboard.putBoolean("IMU present", RobotMap.imu.isSensorPresent());
                 SmartDashboard.putBoolean("IMU initialized", RobotMap.imu.isInitialized());
-                SmartDashboard.putNumber("IMU heading", num);
-                SmartDashboard.putNumber("IMU calibration status", (1000 + (calData.accel * 100) + calData.gyro * 10 + calData.mag)); // Calibration
-                                                                                                                                      // values
-                                                                                                                                      // range
-                                                                                                                                      // from
-                                                                                                                                      // 0-3,
-                                                                                                                                      // Right
-                                                                                                                                      // to
-                                                                                                                                      // left:
-                                                                                                                                      // mag,
-                                                                                                                                      // gyro,
-                                                                                                                                      // accel
-
+                SmartDashboard.putNumber("IMU calibration status", 
+                        (1000 + (calData.accel * 100) + 
+                        calData.gyro * 10 + 
+                        calData.mag)); 
+                // Calibration values range from 0-3, 
+                // Right to left: mag, gyro, accel
             }
         }
     }

--- a/src/org/usfirst/frc/team4915/stronghold/subsystems/DriveTrain.java
+++ b/src/org/usfirst/frc/team4915/stronghold/subsystems/DriveTrain.java
@@ -115,4 +115,25 @@ public class DriveTrain extends Subsystem {
             robotDrive.arcadeDrive(0, .7);
         }
     }
+
+    // autoturn is just a gentler version of (joystick) turn.
+    public void autoturn(boolean left) {
+        if (ModuleManager.GYRO_MODULE_ON) {
+            trackGyro();
+        }
+        if (left) {
+            robotDrive.arcadeDrive(0, -.2);
+        } else {
+            robotDrive.arcadeDrive(0, .2);
+        }
+    }
+
+    public void turnToward(double heading) {
+        double deltaHeading = RobotMap.imu.getHeading() - heading;
+        if (Math.abs(deltaHeading) < 1.0)
+            this.stop();
+        else
+            this.autoturn(deltaHeading < 0.0);
+    }
+
 }

--- a/src/org/usfirst/frc/team4915/stronghold/vision/jetson/imgExplore2/robotCnx.py
+++ b/src/org/usfirst/frc/team4915/stronghold/vision/jetson/imgExplore2/robotCnx.py
@@ -28,6 +28,7 @@ class RobotCnx:
             self.targetState = targetState.TargetState(self.visTable)
             self.targetHigh = True
             self.autoAimEnabled = False
+            self.imuHeading = 0
 
         except:
             xcpt = sys.exc_info()
@@ -36,6 +37,9 @@ class RobotCnx:
 
     def GetTargetState(self):
         return self.targetState
+
+    def GetIMUHeading(self):
+        return self.imuHeading
 
     def SetFPS(self, fps):
         self.targetState.SetFPS(fps)
@@ -53,12 +57,17 @@ class RobotCnx:
 
     @staticmethod
     def visValueChanged(table, key, value, isNew):
-        #This is where we can be woken up if the driver station (or robot) wants to talk to us
+        # This is where we can be woken up if the driver station 
+        # (or robot) wants to talk to us. This method fires only
+        # on changes to /SmartDashboard/Vision/*
         if key == 'TargetHigh':
         	self.targetHigh = value
             #print(value)
         elif key == 'AutoAimEnabled':
         	self.autoAimEnabled = value
+            #print(value)
+        elif key == 'IMUHeading':
+        	self.imuHeading = value
             #print(value)
         else:
             pass

--- a/src/org/usfirst/frc/team4915/stronghold/vision/jetson/imgExplore2/targetState.py
+++ b/src/org/usfirst/frc/team4915/stronghold/vision/jetson/imgExplore2/targetState.py
@@ -54,11 +54,11 @@ class TargetState:
     	kp1Frequency = 0
     	kp2Frequency = 0
     	for kp in self.m_56kpHistory:
-    		if (kp.pt[0]-3 < kp1.pt[0] < kp.pt[0]+3) and 
-    		(kp.pt[1]-3 < kp1.pt[1] < kp.pt[1]+3):
+    		if (kp.pt[0]-3 < kp1.pt[0] < kp.pt[0]+3) and \
+                (kp.pt[1]-3 < kp1.pt[1] < kp.pt[1]+3):
     			kp1Frequency += 1
-    		if (kp.pt[0]-3 < kp2.pt[0] < kp.pt[0]+3) and \ 
-    		(kp.pt[1]-3 < kp2.pt[1] < kp.pt[1]+3):
+    		if (kp.pt[0]-3 < kp2.pt[0] < kp.pt[0]+3) and \
+                (kp.pt[1]-3 < kp2.pt[1] < kp.pt[1]+3):
     			kp2Frequency += 1
         if kp1Frequency > kp2Frequency:  # sort most frequent to front of list
             return -1
@@ -98,6 +98,9 @@ class TargetState:
     	self.m_kp.pt = (avgKeypointX / 5, avgKeypointY / 5)
     	return self.m_kp
     
+    def NewTarget(self, target):
+        self.updateVisionTableAbsolute(target)
+
     def NewKeypoints(self, kplist):
         if len(kplist) > 0:
             if 0:
@@ -160,24 +163,37 @@ class TargetState:
                 sys.stdout.write("\n")
         else:
             self.m_kp = None
-        self.updateVisionTable()
+        self.updateVisionTable(self.m_kp)
         return kplist
 
-    def updateVisionTable(self):
-        kp = self.m_kp
+    def pixelToAngle(self, pt):
+        x = self.m_fov[0] * (pt[0] - self.m_center[0]) / self.m_res[0];
+        y = self.m_fov[1] * (pt[1] - self.m_center[1]) / self.m_res[1];
+        return (x,y)
+
+    def updateVisionTable(self, kp):
+        self.m_visTab.putInt("RelativeTargetingMode", 1)
         if not kp:
             self.m_visTab.putInt("TargetsAcquired", 0)
         else:
             theta = self.pixelToAngle(kp.pt)
             self.m_visTab.putInt("TargetsAcquired", 1)
             self.m_visTab.putInt("TargetX", int(.5+theta[0]))
-            self.m_visTab.putInt("TargetY", int(.5++theta[1]))
+            self.m_visTab.putInt("TargetY", int(.5+theta[1]))
             self.m_visTab.putNumber("TargetSize", int(.5+kp.size))
             self.m_visTab.putNumber("TargetResponse", kp.response)
             self.m_visTab.putInt("TargetClass", kp.class_id)
 
-    def pixelToAngle(self, pt):
-        x = self.m_fov[0] * (pt[0] - self.m_center[0]) / self.m_res[0];
-        y = self.m_fov[1] * (pt[1] - self.m_center[1]) / self.m_res[1];
-        return (x,y)
+    def updateVisionTableAbsolute(self, target):
+        self.m_visTab.putInt("RelativeTargetingMode", 0)
+        if not target:
+            self.m_visTab.putInt("TargetsAcquired", 0)
+        else:
+            self.m_visTab.putInt("TargetsAcquired", 1)
+            self.m_visTab.putInt("TargetX", int(.5+target[0]))
+            self.m_visTab.putInt("TargetY", int(.5+target[1]))
+            self.m_visTab.putNumber("TargetSize", 0)
+            self.m_visTab.putNumber("TargetResponse", 0)
+            self.m_visTab.putInt("TargetClass", -1)
+
 

--- a/src/org/usfirst/frc/team4915/stronghold/vision/robot/VisionState.java
+++ b/src/org/usfirst/frc/team4915/stronghold/vision/robot/VisionState.java
@@ -21,8 +21,13 @@ public class VisionState implements NamedSendable {
         return s_instance;
     }
 
+    // these values originate from robot / driverstation
     public boolean AutoAimEnabled = false;
     public boolean TargetHigh = true;
+    public int IMUHeading = 0; 
+
+    // these values originate from jetson
+    public boolean RelativeTargetingMode = true;
     public int FPS = 0;
     public int TargetsAcquired = 0;
     public int TargetX = 0;
@@ -31,27 +36,33 @@ public class VisionState implements NamedSendable {
     public double TargetResponse = 0;
     public int TargetClass = 0;
 
+
     private ITable m_table = null;
     private final ITableListener m_listener = new ITableListener() {
 
         @Override
-        public void valueChanged(ITable table, String key, Object value, boolean isNew) {
+        public void valueChanged(ITable table, String key, Object value, 
+                                boolean isNew) 
+        {
             /*
              * All numbers are stored as doubles in the network tables, event
              * those posted as int, float.
              */
             // System.out.println();
-            System.out.println(key + " " + value + " " + value.getClass().getName());
             if (key.equals("~TYPE~")) {
                 return;
             } else if (key.equals(("AutoAimEnabled"))) {
                 s_instance.AutoAimEnabled = (Boolean) value;
+            } else if (key.equals(("RelativeTargetingMode"))) {
+                s_instance.RelativeTargetingMode = (Boolean) value;
             } else {
                 // System.out.println(key + " " + value);
                 double num = (Double) value;
                 int ival = (int) num;
                 if (key.equals("FPS"))
                     s_instance.FPS = ival;
+                else if (key.equals("IMUHeading"))
+                    s_instance.IMUHeading = ival;
                 else if (key.equals("TargetsAcquired"))
                     s_instance.TargetsAcquired = ival;
                 else if (key.equals("TargetX"))
@@ -64,6 +75,9 @@ public class VisionState implements NamedSendable {
                     s_instance.TargetResponse = num;
                 else if (key.equals("TargetClass"))
                     s_instance.TargetClass = ival;
+                else
+                    System.out.println(key + " " + value + " " + 
+                                       value.getClass().getName());
             }
         }
     };
@@ -88,25 +102,26 @@ public class VisionState implements NamedSendable {
         if (this.m_table != null)
             this.m_table.removeTableListener(m_listener);
         this.m_table = subtable;
-        m_table.addTableListenerEx(m_listener, ITable.NOTIFY_NEW | ITable.NOTIFY_IMMEDIATE);
-
+        m_table.addTableListenerEx(m_listener, 
+                                  ITable.NOTIFY_NEW|ITable.NOTIFY_IMMEDIATE);
         this.AutoAimEnabled = m_table.getBoolean("AutoAimEnabled", false);
+        this.RelativeTargetingMode =    
+                        m_table.getBoolean("RelativeTargetingMode", true);
         this.TargetHigh = m_table.getBoolean("TargetHigh", true);
         this.FPS = (int) m_table.getNumber("FPS", 0.);
+        this.IMUHeading = (int) m_table.getNumber("IMUHeading", 0.);
         this.TargetsAcquired = (int) m_table.getNumber("TargetsAcquired", 0);
         this.TargetX = (int) m_table.getNumber("TargetX", 0);
         this.TargetY = (int) m_table.getNumber("TargetY", 0);
         this.TargetSize = (int) m_table.getNumber("TargetSize", 0);
         this.TargetResponse = m_table.getNumber("TargetResponse", 0.);
         this.TargetClass = (int) m_table.getNumber("TargetClass", 0);
-
     }
 
     public void toggleAimState(boolean toggleEnable, boolean toggleTarget) {
         if (toggleEnable) {
             this.AutoAimEnabled = !this.AutoAimEnabled;
             m_table.putBoolean("AutoAimEnabled", this.AutoAimEnabled);
-            System.out.println("AutoAimEnabled:" + this.AutoAimEnabled);
             setLight(this.AutoAimEnabled);
         }
         if (toggleTarget) {
@@ -114,6 +129,10 @@ public class VisionState implements NamedSendable {
             // m_table.putBoolean("TargetHigh", this.TargetHigh);
             System.out.println("TargetHigh:" + this.TargetHigh);
         }
+    }
+
+    public void updateIMUHeading(double heading) {
+        m_table.putNumber("IMUHeading", (int)(heading+.5));
     }
 
     /*


### PR DESCRIPTION
- imu needs to deliver (absolute) heading to vision state (on jetson)
- separated out the turn methods invoked by joytstick vs autotarget
- assorted cleanups

Still TODO: get jetson 'dance' to work in absolute mode.
